### PR TITLE
Added the ability for a project specific .jshint file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -10,11 +10,30 @@ function _version() {
     _sys.print(JSON.parse(_fs.readFileSync(__dirname + "/../package.json", "utf-8")).version + "\n");
 }
 
+function _mergeConfigs(homerc, cwdrc) {
+    var homeConfig = JSON.parse(_fs.readFileSync(homerc, "utf-8")),
+        cwdConfig = JSON.parse(_fs.readFileSync(cwdrc, "utf-8"));
+
+    for (var prop in cwdConfig) {
+      if (typeof prop === 'string') {
+
+        if (prop === 'predef') {
+          var merged = homeConfig.predef.concat(cwdConfig.predef);
+          homeConfig.predef = merged;
+        } else {
+          homeConfig[prop] = cwdConfig[prop];
+        }
+      }
+    }
+    return homeConfig;
+}
+
 module.exports = {
     interpret: function (args) {
         var config, reporter,
             options = require('argsparser').parse(args),
             defaultConfig = _path.join(process.env.HOME, '.jshintrc'),
+            projectConfig = _path.join(process.cwd(), '.jshintrc'),
             customConfig = options["--config"],
             customReporter = options["--reporter"],
             targets = typeof options.node === "string" ?
@@ -44,7 +63,7 @@ module.exports = {
             }
         } else {
             try {
-                config = JSON.parse(_fs.readFileSync(defaultConfig, "utf-8"));
+                config = _mergeConfigs(defaultConfig, projectConfig);
             } catch (f) {}
         }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -64,6 +64,25 @@ describe("cli", function () {
         expect(fs.readFileSync).toHaveBeenCalledWith(path.join(process.env.HOME, '.jshintrc'), "utf-8");
     });
 
+    it("looks for a project specific config file", function () {
+        var config = {prefdef: []},
+            path = require('path');
+
+        spyOn(fs, "readFileSync").andReturn(JSON.stringify(config));
+        cli.interpret(["node", "file.js", "file.js"]);
+        expect(fs.readFileSync).toHaveBeenCalledWith(path.join(process.cwd(), '.jshintrc'), "utf-8");
+    });
+
+    it("overrides options from the $HOME .jshintrc file with options from the cwd .jshintrc file", function() {
+        var config = '{"evil": true,"predef":["Monkeys","Elephants"]}';
+        fs.writeFileSync('.jshintrc', config, "utf-8");
+        cli.interpret(["node", "file.js", "file.js"]);
+        expect(hint.hint.mostRecentCall.args[1].predef).toContain("Monkeys");
+        expect(hint.hint.mostRecentCall.args[1].predef).toContain("Elephants");
+        expect(hint.hint.mostRecentCall.args[1].evil).toEqual(true);
+        fs.unlinkSync('.jshintrc');
+    });
+
     it("interprets --version and logs the current package version", function () {
         var data = {version: 1};
 


### PR DESCRIPTION
Tests included. Options in a `.jshintrc` file from a user's `$HOME` directory are overridden by options within a `.jshintrc` file in the `cwd`.

If options within the `cwd` are set, they will override the options set within the `$HOME` directory. The only special case is the `predef` option which is additive to what already exists in the `$HOME/.jshintrc` file.

The main use case I came up with is based on the `predef` option. If you have a project with global namespaces for `Monkeys` and `Elephants` you could include this in a `./.jshintrc` file as:

```
{
  "predef": [
  "Monkeys",
  "Elephants"
  ]
}
```

This way there is no need to pollute each file with `/*global Monkeys Elephants */`. The tests probably explain this better than I can. 

The main drawback of this is speed. I created a [benchmark repository](https://github.com/mkitt/jshint-config-merge-bench) which shows the difference between the different access points. While running from the cli, it's not a big deal. I have JSHint hooked into a buffer save for Vim (I have a TextMate bundle as well if you're interested) and it's tolerable for sure.

Let me know if you would like to see any changes, additions or have any questions.

thanks.
mk
