### PR TITLE
Fixed a reporter crash

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -50,7 +50,8 @@ module.exports = {
 
         if (customReporter) {
             try {
-                eval(_fs.readFileSync(customReporter, "utf-8"));
+                //eval(_fs.readFileSync(customReporter, "utf-8"));
+                var reporter = require(customReporter).reporter;
             } catch (r) {
                 _sys.puts("Error opening reporter file: " + customReporter);
                 _sys.puts(r + "\n");

--- a/lib/jslint_reporter.js
+++ b/lib/jslint_reporter.js
@@ -1,11 +1,16 @@
+(function(){
+"use strict";
 // Author: Vasili Sviridov
 // http://github.com/vsviridov
-function reporter(results) {
-    "use strict";
-    console.log("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-    console.log("<jslint>");
+module.exports = 
+{
+    reporter: function(results)
+    {
+        "use strict";
+        console.log("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+        console.log("<jslint>");
 
-    var files = {},
+        var files = {},
         pairs = {
             "&": "&amp;",
             '"': "&quot;",
@@ -14,30 +19,34 @@ function reporter(results) {
             ">": "&gt;"
         },
         file, i, issue;
-	
-    function encode(s) {
-        for (var r in pairs) {
-            s = s.replace(new RegExp(r, "g"), pairs[r]);
-        }
-        return s;
-    }
 
-    results.forEach(function (result) {
-        result.file = result.file.replace(/^\.\//, '');
-        if (!files[result.file]) {
-            files[result.file] = [];
+        function encode(s) {
+            for (var r in pairs) {
+                if(typeof(s) !== "undefined") {
+                    s = s.replace(new RegExp(r, "g"), pairs[r]);
+                }
+            }
+            return s || "";
         }
-        files[result.file].push(result.error);
-    });
-	
-    for (file in files) {
-        console.log("\t<file name=\"%s\">", file);
-        for (i = 0; i < files[file].length; i++) {
-            issue = files[file][i];
-            console.log("\t\t<issue line=\"%d\" char=\"%d\" reason=\"%s\" evidence=\"%s\" />", issue.line, issue.character, encode(issue.reason), encode(issue.evidence));
-        }
-        console.log("\t</file>");
-    }
 
-    console.log("</jslint>");
+        results.forEach(function (result) {
+            result.file = result.file.replace(/^\.\//, '');
+            if (!files[result.file]) {
+                files[result.file] = [];
+            }
+            files[result.file].push(result.error);
+        });
+
+        for (file in files) {
+            console.log("\t<file name=\"%s\">", file);
+            for (i = 0; i < files[file].length; i++) {
+                issue = files[file][i];
+                console.log("\t\t<issue line=\"%d\" char=\"%d\" reason=\"%s\" evidence=\"%s\" />", issue.line, issue.character, encode(issue.reason), encode(issue.evidence));
+            }
+            console.log("\t</file>");
+        }
+        console.log("</jslint>");
+    }
 }
+
+}());


### PR DESCRIPTION
~Switched reporter to `require()` instead of `eval()`
~Fixed a crash when `evidence` was `undefined`

Switched to `require()` because it was hard to find bugs in reporter if it was `eval`'d. Stack trace would be lost at `eval()`.

Also, even though @antonkovalyov mentioned that it should take shebang fine - it seems to stop processing as soon as it gets there :)

Do I have to enable additional option for that?
