### PR TITLE
Added the path to the executable for npm rc 1.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "type": "MIT",
     "url": "http://www.opensource.org/licenses/mit-license.php"
   }],
-  "main": "./packages/jshint/jshint",
+  "bin": { "jshint": "./bin/jshint" },
+  "main": "packages/jshint/jshint",
   "files": [
     "packages/jshint/README.markdown",
     "packages/jshint/jshint.js",


### PR DESCRIPTION
This should work in older versions of npm as well. Without the `bin` reference for npm 1.0.x it won't get installed into a PATH for the user. I just upgraded npm this evening and adding this in and running `npm link` seems to work fine. Let me know if you have any questions.
