### PR TITLE
_mergeConfigs, missing .jshintrc

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,9 +11,12 @@ function _version() {
 }
 
 function _mergeConfigs(homerc, cwdrc) {
-    var homeConfig = JSON.parse(_fs.readFileSync(homerc, "utf-8")),
-        cwdConfig = JSON.parse(_fs.readFileSync(cwdrc, "utf-8")),
+    var homeConfig = {},
+        cwdConfig = {},
         prop;
+
+    if (_path.existsSync(homerc)) homeConfig = JSON.parse(_fs.readFileSync(homerc, "utf-8"));
+    if (_path.existsSync(cwdrc)) cwdConfig = JSON.parse(_fs.readFileSync(cwdrc, "utf-8"));
 
     for (prop in cwdConfig) {
         if (typeof prop === 'string') {


### PR DESCRIPTION
If either the $HOME/.jshintrc or the project specific .jshintrc is missing, fs.readFileSync in _mergeConfigs throws `Error: EBADF, Bad file descriptor` and silently fails because of the try/catch https://github.com/jshint/node-jshint/blob/master/lib/cli.js#L64
The result is that neither .jshintrc is used.

I'm fairly new to node, so my changes might not be the best way to handle this case.
