### PR TITLE
Defining predef in the default values for homerc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tags
+node_modules

--- a/README.md
+++ b/README.md
@@ -31,10 +31,14 @@ The cli uses the default options that come with jshint, however if it locates a 
 
 If there is a .jshintrc file in the current working directory, it will be merged into the default options.
 
-## Running Tests
+## Installing dependencies for development
 
+    npm install argparser@0.03
     git submodule init
     git submodule update
+
+
+## Running Tests
 
     npm install jasmine-node
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,8 +15,18 @@ function _mergeConfigs(homerc, cwdrc) {
         cwdConfig = {},
         prop;
 
-    if (_path.existsSync(homerc)) homeConfig = JSON.parse(_fs.readFileSync(homerc, "utf-8"));
-    if (_path.existsSync(cwdrc)) cwdConfig = JSON.parse(_fs.readFileSync(cwdrc, "utf-8"));
+    try{
+        if (_path.existsSync(homerc)) homeConfig = JSON.parse(_fs.readFileSync(homerc, "utf-8"));
+    } catch (e) {
+        _sys.puts("Error opening config file " + homerc + '\n');
+        _sys.puts(e + "\n");
+    }
+    try{
+        if (_path.existsSync(cwdrc)) cwdConfig = JSON.parse(_fs.readFileSync(cwdrc, "utf-8"));
+    } catch (e) {
+        _sys.puts("Error opening config file " + cwdrc + '\n');
+        _sys.puts(e + "\n");
+    }
 
     for (prop in cwdConfig) {
         if (typeof prop === 'string') {
@@ -66,7 +76,10 @@ module.exports = {
         } else {
             try {
                 config = _mergeConfigs(defaultConfig, projectConfig);
-            } catch (f) {}
+            } catch (f) {
+                _sys.puts("Error opening config file " + defaultConfig + " or " + projectConfig);
+                _sys.puts(e + "\n");
+            }
         }
 
         if (customReporter) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,7 +21,7 @@ function _mergeConfigs(homerc, cwdrc) {
     for (prop in cwdConfig) {
         if (typeof prop === 'string') {
             if (prop === 'predef') {
-                homeConfig.predef = homeConfig.predef.concat(cwdConfig.predef);
+                homeConfig.predef = (homeConfig.predef || []).concat(cwdConfig.predef);
             } else {
                 homeConfig[prop] = cwdConfig[prop];
             }


### PR DESCRIPTION
This change fixes a problem that occurs when predef is defined in a project file but there is no homeconfig.
