### PR TITLE
Add bin to "files" array. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "packages/jshint/jshint.js",
     "README.md",
     "LICENSE",
-    "HELP"
+    "HELP",
+    "bin/hint"
   ],
   "dependencies": {
     "argsparser": ">=0.0.3"


### PR DESCRIPTION
The "files" array, if provided, specifies the _only_ files that should
be included by npm in the package.  Since the bin isn't on that list,
it's causing problems.
