### PR TITLE
Allow for Unicode Byte Order Mark in analyzed files

### DIFF
--- a/lib/hint.js
+++ b/lib/hint.js
@@ -18,6 +18,9 @@ function _lint(file, results, config, data) {
         process.stdout.write(e + '\n');
     }
 
+    // Remove potential Unicode Byte Order Mark.
+    buffer = buffer.replace(/^\uFEFF/, '');
+
     if (!jshint.JSHINT(buffer, config)) {
         jshint.JSHINT.errors.forEach(function (error) {
             if (error) {


### PR DESCRIPTION
Allow for Unicode Byte Order Mark in analyzed files. node-jshint reads with fs.readFileSync with utf-8 encoding, but node.js keeps BOM in the returned string (see https://github.com/joyent/node/issues/1918) which is detected by jshint as unsafe characters.
