### PR TITLE
Issue #52 - Quick fix for Windows support

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -73,12 +73,10 @@ module.exports = {
         //could be on Windows which we are looking for an attribute ending in 'node.exe'
         if (targets === undefined) {
             (function () {
-                var arg,
-                    tokens;
+                var arg;
 
                 for (arg in options) {
-                    tokens = arg.split("\\");
-                    if (tokens[tokens.length - 1] === 'node.exe') {
+                    if (path.basename(arg) === 'node.exe') {
                         targets = options[arg];
                         break;
                     }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -81,7 +81,7 @@ module.exports = {
                         break;
                     }
                 }
-            })();
+            }());
         }
 
         targets = typeof targets === "string" ? null : targets.slice(1);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -68,7 +68,26 @@ module.exports = {
             projectConfig = path.join(process.cwd(), '.jshintrc'),
             customConfig = options["--config"],
             customReporter = options["--reporter"] ? path.resolve(process.cwd(), options["--reporter"]) : null,
-            targets = typeof options.node === "string" ? null : options.node.slice(1);
+            targets = options.node;
+       
+        //could be on Windows which we are looking for an attribute ending in 'node.exe'
+        if (targets === undefined) {
+            (function () {
+                var arg,
+                    tokens;
+
+                for (arg in options) {
+                    tokens = arg.split("\\");
+                    if (tokens[tokens.length - 1] === 'node.exe') {
+                        targets = options[arg];
+                        break;
+                    }
+                }
+            })();
+        }
+
+        targets = typeof targets === "string" ? null : targets.slice(1);
+
 
         if (options["--version"]) {
             _version();


### PR DESCRIPTION
The node argument comes in full path with a .exe on the end. Added a bit of code after the arguments are parsed to check for it. I've used it for a day with the syntastic plug-in in VIM. Also ran the jasmine specs for the project and tried a glob on OS X. Things seem to be working.
