### PR TITLE
Fix issue #55, where there are trailing \r on Windows.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -122,7 +122,9 @@ module.exports = {
         }
 
         if (path.existsSync(pathsToIgnore)) {
-            ignore = fs.readFileSync(pathsToIgnore, "utf-8").split("\n").filter(function (line) {
+            ignore = fs.readFileSync(pathsToIgnore, "utf-8").split("\n").map(function(line) {
+                return line.trim();
+            }).filter(function (line) {
                 return !!line;
             });
         }


### PR DESCRIPTION
On Windows, line endings have \r\n. If you split on just \n (as jshint does), then we will have trailing \r at the end of each ignore file, which will cause nothing to match.
