### PR TITLE
Fix issue #63, accepts input via stdin

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -84,15 +84,19 @@ module.exports = {
             }());
         }
 
-        targets = typeof targets === "string" ? null : targets.slice(1);
+        targets = typeof targets === "string" ? [] : targets.slice(1);
 
+        // Accept a dash as a file path to read from stdin.
+        if (options['-']) {
+            targets.push('/dev/stdin');
+        }
 
         if (options["--version"]) {
             _version();
             return;
         }
 
-        if (!targets || options["--help"]) {
+        if (targets.length < 1 || options["--help"]) {
             _help();
             return;
         }

--- a/lib/hint.js
+++ b/lib/hint.js
@@ -78,7 +78,7 @@ function _collect(filePath, files, ignore) {
         fs.readdirSync(filePath).forEach(function (item) {
             _collect(path.join(filePath, item), files, ignore);
         });
-    } else if (filePath.match(/\.js$/)) {
+    } else if (filePath.match(/\.js$/) || filePath.match(/stdin/)) {
         files.push(filePath);
     }
 }

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -182,4 +182,10 @@ describe("cli", function () {
         expect(process.stdout.on.argsForCall[0][0]).toBe("drain");
         expect(process.exit).toHaveBeenCalledWith(1);
     });
+
+    it("reads input from stdin if `-` is given as a file path", function () {
+        cli.interpret(["node", "hint", "-"]);
+
+        expect(hint.hint.mostRecentCall.args[0]).toContain("/dev/stdin");
+    });
 });

--- a/test/unit/hint.js
+++ b/test/unit/hint.js
@@ -168,6 +168,14 @@ describe("hint", function () {
         expect(fs.readFileSync.argsForCall[0][0]).toBe("dir/foo/test.js");
     });
 
+    it("reads input from stdin", function() {
+        spyOn(fs, "readFileSync").andReturn("data");
+
+        hint.hint(["/dev/stdin"]);
+
+        expect(fs.readFileSync).toHaveBeenCalledWith("/dev/stdin", "utf-8");
+    });
+
     // TODO: handles jshint errors (will tighten custom reporter assertions)
     // TODO: handles file open error
     // TODO: handling of JSHINT.data()


### PR DESCRIPTION
To read files from stdin, give a dash (-) in place of a file path.  For example:

```
cat some_file.js | jshint -
```

This matches the conventions of established Unix tools like grep.

The implementation in this changeset is platform dependent, since the only way that I know of to read from stdin synchronously is to call `fs.readFileSync('/dev/stdin', 'utf-8')`.  I also put together an async refactor that might allow reading from stdin to work on platforms that do not have a /dev/stdin file (i.e. Windows).  But that would be a much bigger change.
