### PR TITLE
Fix issue in spawn where args are not properly attached

### DIFF
--- a/build/lint.js
+++ b/build/lint.js
@@ -1,13 +1,14 @@
 module.exports = function (files) {
     var args = files && files.length > 0 ? files : ["."],
         exec = require('child_process').exec,
-        opts = args.concat(["--config .jshintrc", "--show-non-errors"]).join(' '),
-        cmd = exec("jshint " + opts);
-
-    function write(data) {
-        process.stdout.write(new Buffer(data).toString("utf-8"));
-    }
-
-    cmd.stdout.on('data', write);
-    cmd.stderr.on('data', write);
+        opts = args.concat(["--config .jshintrc", "--show-non-errors"]).join(' ');
+    
+    exec("jshint " + opts, function (err, stdout, stderr) {
+        if (stdout) {
+            console.log(stdout);
+        }
+        if (stderr) {
+            console.log(stderr);
+        }
+    });
 };

--- a/build/lint.js
+++ b/build/lint.js
@@ -1,7 +1,8 @@
 module.exports = function (files) {
     var args = files && files.length > 0 ? files : ["."],
-        spawn = require('child_process').spawn,
-        cmd = spawn("jshint", args.concat(["--show-non-errors"]));
+        exec = require('child_process').exec,
+        opts = args.concat(["--config .jshintrc", "--show-non-errors"]).join(' '),
+        cmd = exec("jshint " + opts);
 
     function write(data) {
         process.stdout.write(new Buffer(data).toString("utf-8"));

--- a/build/lint.js
+++ b/build/lint.js
@@ -1,14 +1,13 @@
 module.exports = function (files) {
     var args = files && files.length > 0 ? files : ["."],
-        exec = require('child_process').exec,
-        opts = args.concat(["--config .jshintrc", "--show-non-errors"]).join(' ');
-    
-    exec("jshint " + opts, function (err, stdout, stderr) {
-        if (stdout) {
-            console.log(stdout);
-        }
-        if (stderr) {
-            console.log(stderr);
-        }
-    });
+        spawn = require('child_process').spawn,
+        cmd = spawn("jshint", args.concat(["--config", ".jshintrc", "--show-non-errors"]));
+
+    function write(data) {
+        process.stdout.write(new Buffer(data).toString("utf-8"));
+    }
+
+    cmd.stdout.on('data', write);
+    cmd.stderr.on('data', write);
+
 };


### PR DESCRIPTION
When running `jake lint` (RE: [#87](https://github.com/jshint/node-jshint/pull/87)), I was getting an enormous output and realized that it was a result of the spawned process not using the `--config` flag, and merging in my default `jshintrc` opts. I tried to add the `--config` flag in several ways using `spawn` but failed:

https://gist.github.com/1998016

What ended up working was using `exec`. I am not sure what actually causes this and unfortunately I don't really have the time to look into it now but this fix seems to work. Also I am not sure if or where a test would need to be implemented for this fix. So let me know if I need to do anything there.

Thanks.
