### PR TITLE
Fixing infinite recursion while searching for .jshintrc on Windows.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,8 @@ var fs = require('fs'),
     argsparser = require('argsparser'),
     hint = require('./hint');
 
+var rootPath = path.resolve("/");
+
 function existsSync() {
     var obj = fs.existsSync ? fs : path;
     return obj.existsSync.apply(obj, arguments);
@@ -45,7 +47,7 @@ function _searchFile(name, dir) {
         return filename;
     }
 
-    return dir === "/" ?
+    return dir === rootPath ?
         null : _searchFile(name, path.normalize(path.join(dir, "..")));
 }
 


### PR DESCRIPTION
Closes #100, which has more details. Bug introduced in 897db69bdf16f1515277575035836dddb032351a.
