### PR TITLE
Support overwriting JSHINT options in command line

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -93,7 +93,7 @@ module.exports = {
             customConfig = options["--config"],
             customReporter = options["--reporter"] ? path.resolve(process.cwd(), options["--reporter"]) : null,
             targets = options.node,
-            ignoreFile, ignores;
+            ignoreFile, ignores, k, nodeArgName = 'node';
 
         //could be on Windows which we are looking for an attribute ending in 'node.exe'
         if (targets === undefined) {
@@ -103,6 +103,7 @@ module.exports = {
                 for (arg in options) {
                     if (path.basename(arg) === 'node.exe') {
                         targets = options[arg];
+                        nodeArgName = arg;
                         break;
                     }
                 }
@@ -130,6 +131,14 @@ module.exports = {
         }
 
         config = _loadAndParseConfig(customConfig ? customConfig : _findConfig());
+
+        // Merge JSHINT options given on the command line
+        for (k in options) {
+          if (options.hasOwnProperty(k) &&['--jslint-reporter', nodeArgName,
+              '--show-non-errors'].indexOf(k) === -1) {
+            config[k.replace(/^-+/, '')] = options[k];
+          }
+        }
 
         if (customReporter) {
             try {


### PR DESCRIPTION
This implements #27. Note that the predef syntax is `jshint FILE.js --predef require module`.
