### PR TITLE
Fix config file comment removal

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -10,7 +10,15 @@ function existsSync() {
 
 function _removeJsComments(str) {
     str = str || '';
-    str = str.replace(/\/\*[\s\S]*(?:\*\/)/g, ''); //everything between "/* */"
+
+    // replace everything between "/* */" in a non-greedy way
+    // The English version of the regex is:
+    //   match '/*'
+    //   then match 0 or more instances of any character (including newlines)
+    //     except for instances of '*/'
+    //   then match '*/'
+    str = str.replace(/\/\*(?:(?!\*\/)[\s\S])*\*\//g, '');
+
     str = str.replace(/\/\/[^\n\r]*/g, ''); //everything after "//"
     return str;
 }


### PR DESCRIPTION
This commit fixes the regex that removes `/* */` style comments from the config file.  Previously, the regex was greedy, so it would remove everything between the first `/*` and the last `*/` in the file.  So, if the file looked like this:

``` javascript
{
    /* comment */
    "node" : true,

    /* comment */
    "browser" : true
}
```

then the "node" attribute would be removed from the file.

Now, it only removes things between each `/*` and the next `*/` in the file, so the above file would be cleaned up as expected.
