### PR TITLE
defaults.json: clearer comments

### DIFF
--- a/example/defaults.json
+++ b/example/defaults.json
@@ -2,7 +2,7 @@
 // Defaults as of jshint edition 2011-04-16
 
 {
-    // If the scan should stop on first error.
+    // Whether the scan should stop on first error.
     "passfail": false,
     // Maximum errors before stopping.
     "maxerr": 50,
@@ -10,24 +10,24 @@
 
     // Predefined globals
 
-    // If the standard browser globals should be predefined.
+    // Whether the standard browser globals should be predefined.
     "browser": false,
-    // If the Node.js environment globals should be predefined.
+    // Whether the Node.js environment globals should be predefined.
     "node": false,
-    // If the Rhino environment globals should be predefined.
+    // Whether the Rhino environment globals should be predefined.
     "rhino": false,
-    // If CouchDB globals should be predefined.
+    // Whether CouchDB globals should be predefined.
     "couch": false,
-    // If the Windows Scripting Host environment globals should be predefined.
+    // Whether the Windows Scripting Host environment globals should be predefined.
     "wsh": false,
 
-    // If jQuery globals should be predefined.
+    // Whether jQuery globals should be predefined.
     "jquery": false,
-    // If Prototype and Scriptaculous globals should be predefined.
+    // Whether Prototype and Scriptaculous globals should be predefined.
     "prototypejs": false,
-    // If MooTools globals should be predefined.
+    // Whether MooTools globals should be predefined.
     "mootools": false,
-    // If Dojo Toolkit globals should be predefined.
+    // Whether Dojo Toolkit globals should be predefined.
     "dojo": false,
 
     // Custom predefined globals.
@@ -36,112 +36,112 @@
 
     // Development
 
-    // If debugger statements should be allowed.
+    // Whether debugger statements should be allowed.
     "debug": false,
-    // If logging globals should be predefined (console, alert, etc.).
+    // Whether logging globals should be predefined (console, alert, etc.).
     "devel": false,
 
 
     // ECMAScript 5
 
-    // If ES5 syntax should be allowed.
+    // Whether ES5 syntax should be allowed.
     "es5": false,
-    // Require the "use strict"; pragma.
+    // Whether the "use strict"; pragma should be required.
     "strict": false,
-    // If global "use strict"; should be allowed (also enables strict).
+    // Whether global "use strict"; should be allowed (also enables strict).
     "globalstrict": false,
 
 
     // The Good Parts
 
-    // If automatic semicolon insertion should be tolerated.
+    // Whether automatic semicolon insertion should be allowed.
     "asi": false,
-    // If line breaks should not be checked, e.g. `return [\n] x`.
+    // Whether line breaks should not be checked, e.g. `return [\n] x`.
     "laxbreak": false,
-    // If bitwise operators (&, |, ^, etc.) should not be allowed.
+    // Whether bitwise operators (&, |, ^, etc.) should be forbidden.
     "bitwise": false,
-    // If assignments inside if, for and while should be allowed. Usually
+    // Whether assignments inside `if`, `for` and `while` should be allowed. Usually
     // conditions and loops are for comparison, not assignments.
     "boss": false,
-    // If curly braces around all blocks should be required.
+    // Whether curly braces around all blocks should be required.
     "curly": false,
-    // If === should be required.
+    // Whether `===` and `!==` should be required (instead of `==` and `!=`).
     "eqeqeq": false,
-    // If == null comparisons should be tolerated.
+    // Whether `== null` comparisons should be allowed, even if `eqeqeq` is `true`.
     "eqnull": false,
-    // If eval should be allowed.
+    // Whether `eval` should be allowed.
     "evil": false,
-    // If ExpressionStatement should be allowed as Programs.
+    // Whether ExpressionStatement should be allowed as Programs.
     "expr": false,
-    // If `for in` loops must filter with `hasOwnPrototype`.
+    // Whether `for in` loops must filter with `hasOwnPrototype`.
     "forin": false,
-    // If immediate invocations must be wrapped in parens, e.g.
+    // Whether immediate invocations must be wrapped in parens, e.g.
     // `( function(){}() );`.
     "immed": false,
-    // If use before define should not be tolerated.
+    // Whether use before define should be forbidden.
     "latedef": false,
-    // If functions should be allowed to be defined within loops.
+    // Whether functions should be allowed to be defined within loops.
     "loopfunc": false,
-    // If arguments.caller and arguments.callee should be disallowed.
+    // Whether arguments.caller and arguments.callee should be forbidden.
     "noarg": false,
-    // If the . should not be allowed in regexp literals.
+    // Whether `.` should be forbidden in regexp literals.
     "regexp": false,
-    // If unescaped first/last dash (-) inside brackets should be tolerated.
+    // Whether unescaped first/last dash (-) inside brackets in regexps should be allowed.
     "regexdash": false,
-    // If script-targeted URLs should be tolerated.
+    // Whether script-targeted URLs should be allowed.
     "scripturl": false,
-    // If variable shadowing should be tolerated.
+    // Whether variable shadowing should be allowed.
     "shadow": false,
-    // If `new function () { ... };` and `new Object;` should be tolerated.
+    // Whether `new function () { ... };` and `new Object;` should be allowed.
     "supernew": false,
-    // If variables should be declared before used.
+    // Whether variables must be declared before used.
     "undef": false,
-    // If `this` inside a non-constructor function is valid.
+    // Whether `this` inside a non-constructor function should be allowed.
     "validthis": false,
-    // If smarttabs should be tolerated
+    // Whether smarttabs should be allowed
     // (http://www.emacswiki.org/emacs/SmartTabs).
     "smarttabs": false,
-    // If the `__proto__` property should be allowed.
+    // Whether the `__proto__` property should be allowed.
     "proto": false,
-    // If one case switch statements should be allowed.
+    // Whether one-case switch statements should be allowed.
     "onecase": false,
-    // If non-standard (but widely adopted) globals should be predefined.
+    // Whether non-standard (but widely adopted) globals should be predefined.
     "nonstandard": false,
     // Allow multiline strings.
     "multistr": false,
-    // If line breaks should not be checked around commas.
+    // Whether line breaks should not be checked around commas.
     "laxcomma": false,
-    // If semicolons may be ommitted for the trailing statements inside of a
+    // Whether semicolons may be ommitted for the trailing statements inside of a
     // one-line blocks.
     "lastsemic": false,
-    // If the `__iterator__` property should be allowed.
+    // Whether the `__iterator__` property should be allowed.
     "iterator": false,
-    // If only function scope should be used for scope tests.
+    // Whether only function scope should be used for scope tests.
     "funcscope": false,
-    // If es.next specific syntax should be allowed.
+    // Whether es.next specific syntax should be allowed.
     "esnext": false,
 
 
     // Style preferences
 
-    // If constructor names must be capitalized.
+    // Whether constructor names must be capitalized.
     "newcap": false,
-    // If empty blocks should be disallowed.
+    // Whether empty blocks should be forbidden.
     "noempty": false,
-    // If using `new` for side-effects should be disallowed.
+    // Whether using `new` for side-effects should be forbidden.
     "nonew": false,
-    // If names should be checked for leading or trailing underscores
-    // (object._attribute would be disallowed).
+    // Whether names should be checked for leading or trailing underscores
+    // (object._attribute would be forbidden).
     "nomen": false,
-    // If only one var statement per function should be allowed.
+    // Whether only one var statement per function should be allowed.
     "onevar": false,
-    // If increment and decrement (`++` and `--`) should not be allowed.
+    // Whether increment and decrement (`++` and `--`) should be forbidden.
     "plusplus": false,
-    // If all forms of subscript notation are tolerated.
+    // Whether all forms of subscript notation are allowed.
     "sub": false,
-    // If trailing whitespace rules apply.
+    // Whether trailing whitespace rules apply.
     "trailing": false,
-    // If strict whitespace rules apply.
+    // Whether strict whitespace rules apply.
     "white": false,
     // Specify indentation.
     "indent": 4


### PR DESCRIPTION
- More consistency ("allowed" and "tolerated" both become "allowed")
- No double negatives ("should not be allowed: false" becomes "should be forbidden: false")
- "if" becomes "whether"
- backticks around all code in comments
