### PR TITLE
Fix comment in jshint defaults file

### DIFF
--- a/example/defaults.json
+++ b/example/defaults.json
@@ -72,7 +72,7 @@
     "evil": false,
     // Whether ExpressionStatement should be allowed as Programs.
     "expr": false,
-    // Whether `for in` loops must filter with `hasOwnPrototype`.
+    // Whether `for in` loops must filter with `hasOwnProperty`.
     "forin": false,
     // Whether immediate invocations must be wrapped in parens, e.g.
     // `( function(){}() );`.


### PR DESCRIPTION
The comment explaining the `forin` option in the `defaults.json` file was referencing `hasOwnPrototype`, instead of `hasOwnProperty`.

I'm guessing this was a typo, as [the JSHint documentation](http://www.jshint.com/docs/) states that
the `forin` option requires loops to be filtered with `hasOwnProperty`.
